### PR TITLE
Feat/edit period screen

### DIFF
--- a/src/screens/TrackerScreen.tsx
+++ b/src/screens/TrackerScreen.tsx
@@ -52,7 +52,6 @@ function TrackerScreen({
   const [selectedDate, setSelectedDate] = useState<Date | undefined>()
   const [loggingStep, setLoggingStep] = useState<"start" | "end">("start")
   const [currentEntry, setCurrentEntry] = useState<PeriodEntry | null>(null)
-  const [isEditing, setIsEditing] = useState(false)
   const [showHelpModal, setShowHelpModal] = useState(false);
   const [message, setMessage] = useState<string | null>(null)
 
@@ -60,45 +59,35 @@ function TrackerScreen({
 
 
   const handleSubmit = () => {
-    if (!selectedDate) return
-    
-    if (loggingStep === "start") {
-      // Log start date
-      const newEntry: PeriodEntry = {
-        startDate: selectedDate.toISOString(),
-        endDate: ""
-      }
-      setCurrentEntry(newEntry)
-      setLoggingStep("end")
-      setMessage("Start date logged!")
-      setTimeout(() => setMessage(null), 2000)
-    } else if (loggingStep === "end" && currentEntry) {
-      // Log end date
-      const updatedEntry: PeriodEntry = {
-        ...currentEntry,
-        endDate: selectedDate.toISOString(),
-      }
+  if (!selectedDate) return
 
-      if(isEditing){
-        setPeriodEntries(prev => {
-          const updated = [...prev]
-          updated[updated.length - 1] = updatedEntry
-          return updated
-        })
-
-        setIsEditing(false)
-      } else {
-        setPeriodEntries([...periodEntries, updatedEntry])
-      }
-
-      setCurrentEntry(null)
-      setLoggingStep("start")
-      setMessage("End date logged! Entry saved.")
-      setTimeout(() => setMessage(null), 2000)
+  if (loggingStep === "start") {
+    const newEntry: PeriodEntry = {
+      startDate: selectedDate.toISOString(),
+      endDate: ""
     }
-    
-    setSelectedDate(undefined)
+
+    setCurrentEntry(newEntry)
+    setLoggingStep("end")
+    setMessage("Start date logged!")
+    setTimeout(() => setMessage(null), 2000)
+
+  } else if (loggingStep === "end" && currentEntry) {
+    const updatedEntry: PeriodEntry = {
+      ...currentEntry,
+      endDate: selectedDate.toISOString(),
+    }
+
+    setPeriodEntries([...periodEntries, updatedEntry])
+
+    setCurrentEntry(null)
+    setLoggingStep("start")
+    setMessage("End date logged! Entry saved.")
+    setTimeout(() => setMessage(null), 2000)
   }
+
+  setSelectedDate(undefined)
+}
 
   // Get all the dates to highlight for completed periods
   const { startDates, endDates, rangeDates } = getAllPeriodDates(periodEntries)
@@ -183,19 +172,8 @@ function TrackerScreen({
   onClick={handleSubmit}
   className="w-full py-3 text-base font-medium bg-pink-600 hover:bg-pink-700 focus:ring-pink-500 sm:w-auto sm:px-8"
 >
-  {isEditing? "Save Changes" : loggingStep === "start" ? "Log Start Date" : "Log End Date"}
+  {loggingStep === "start" ? "Log Start Date" : "Log End Date"}
 </Button> 
-
-    {latestEntry?.endDate && !isEditing && (
-  <Button 
-  variant="outline"
-  className="w-full py-3 border-pink-600 text-pink-600 hover:bg-pink-50"
-  onClick={() => setIsEditing(true)}
->
-  Edit Last Entry
-</Button>
-  )}
-     
 
 
 <Link to="/history">

--- a/src/screens/TrackerScreen.tsx
+++ b/src/screens/TrackerScreen.tsx
@@ -187,19 +187,13 @@ function TrackerScreen({
 </Button> 
 
     {latestEntry?.endDate && !isEditing && (
-    <Button 
-    variant="secondary"
-    onClick={() => {
-      if(!latestEntry) return
-
-      setIsEditing(true)
-      setCurrentEntry(latestEntry)
-      setLoggingStep("end")
-      setSelectedDate(undefined)
-    }}
-    >
-      Edit Last Entry
-    </Button>
+  <Button 
+  variant="outline"
+  className="w-full py-3 border-pink-600 text-pink-600 hover:bg-pink-50"
+  onClick={() => setIsEditing(true)}
+>
+  Edit Last Entry
+</Button>
   )}
      
 

--- a/src/screens/TrackerScreen.tsx
+++ b/src/screens/TrackerScreen.tsx
@@ -51,6 +51,7 @@ function TrackerScreen({
   }) {
   const [selectedDate, setSelectedDate] = useState<Date | undefined>()
   const [loggingStep, setLoggingStep] = useState<"start" | "end">("start")
+  const [hasJustLogged, setHasJustLogged] = useState(false)
   const [currentEntry, setCurrentEntry] = useState<PeriodEntry | null>(null)
   const [showHelpModal, setShowHelpModal] = useState(false);
   const [message, setMessage] = useState<string | null>(null)
@@ -82,6 +83,7 @@ function TrackerScreen({
 
     setCurrentEntry(null)
     setLoggingStep("start")
+    setHasJustLogged(true)
     setMessage("End date logged! Entry saved.")
     setTimeout(() => setMessage(null), 2000)
   }
@@ -168,12 +170,24 @@ function TrackerScreen({
  )}
       
 <div className="space-y-2">
-<Button 
-  onClick={handleSubmit}
-  className="w-full py-3 text-base font-medium bg-pink-600 hover:bg-pink-700 focus:ring-pink-500 sm:w-auto sm:px-8"
->
-  {loggingStep === "start" ? "Log Start Date" : "Log End Date"}
-</Button> 
+{!hasJustLogged && (
+  <Button
+    onClick={handleSubmit}
+    className="w-full py-3 bg-pink-600 hover:bg-pink-700 text-white"
+  >
+    {loggingStep === "start" ? "Log Start Date" : "Log End Date"}
+  </Button>
+)}
+
+{hasJustLogged && (
+  <Button
+    variant="secondary"
+    className="w-full"
+    onClick={() => setHasJustLogged(false)}
+  >
+    Log Another Period
+  </Button>
+)}
 
 
 <Link to="/history">


### PR DESCRIPTION
Summary:
- Improved fixes made to the UI experience. 
- Editing option within the tracker screen removed, as it was redundant in the user journey. Instead editing functionality is now within the history screen of the app. 
- The logging button is now hidden after the first set of dates have been logged, and a reset button has been added to add another set of dates for the month. The view logged dates button stays visible.
- The UI is improved with flow for the user. 