### PR TITLE
fix: resolve empty dashboard state and hook ordering issue

### DIFF
--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -16,6 +16,7 @@ import {
   Activity,
   TrendingUp,
   Moon,
+  BarChart3,
 } from "lucide-react";
 import CycleProgressRing from "@/components/CycleProgressRing";
 
@@ -90,6 +91,28 @@ function DashboardScreen({ periodEntries }: Props) {
     () => predictNextPeriod(periodEntries),
     [periodEntries],
   );
+
+  if (periodEntries.length === 0) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center px-6 text-center">
+        <BarChart3 className="w-12 h-12 text-pink-500 mb-4" />
+        <h1 className="text-2xl font-bold text-pink-700">
+          No insights available yet
+        </h1>
+
+        <p className="mt-3 text-gray-600 max-w-sm">
+          Log your first period to start viewing cycle insights and predictions.
+        </p>
+
+        <Link to="/tracker">
+          <Button className="w-full bg-pink-600 hover:bg-pink-700 text-white mt-4">
+            Log First Period
+          </Button>
+        </Link>
+      </div>
+    );
+  }
+
   const lastCycle = getLastCycleLength(periodEntries);
   const consistency = getCycleConsistency(periodEntries);
   const colorClass = consistency ? getConsistencyColor(consistency) : "";


### PR DESCRIPTION
## Fix dashboard empty state and React hook ordering

### What changed

* Added proper empty state handling when no period entries exist
* Prevented dashboard from rendering invalid calculations when data is missing
* Fixed React Hook ordering issue caused by conditional rendering
* Ensured `useMemo` hooks are always called in consistent order

### Why this change was needed

When all period entries were deleted, the dashboard previously rendered a blank or broken state and caused a React Hook violation due to conditional execution of hooks.

### How it works now

* Dashboard checks for empty data after hooks are initialised
* If no data exists, a dedicated empty state screen is shown
* Hooks always run in the same order regardless of data state

### UX impact

* Users are no longer stuck on a blank dashboard
* Clear guidance is shown to log a first period
* Navigation flow is restored and intuitive
