### PR TITLE
Feat/history screen expansion

### DIFF
--- a/src/screens/HistoryScreen.tsx
+++ b/src/screens/HistoryScreen.tsx
@@ -4,6 +4,8 @@ import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { formatPrettyDate } from "@/lib/utils";
 import { moods } from "@/lib/moods";
+import { flows } from "@/lib/flows";
+import { Droplet } from "lucide-react";
 
 interface HistoryScreenProps {
   entries: PeriodEntry[];
@@ -30,6 +32,7 @@ function HistoryScreen({ entries, onDelete }: HistoryScreenProps) {
             {displayedEntries.map((entry, index) => {
               const moodData = moods.find((mood) => mood.value === entry.mood);
               const MoodIcon = moodData?.icon;
+              const flowData = flows.find((flow) => flow.value === entry.flow);
 
               return (
                 <div
@@ -58,15 +61,30 @@ function HistoryScreen({ entries, onDelete }: HistoryScreenProps) {
                             )}
 
                             <span className="capitalize text-gray-700">
-                              {entry.mood}
+                              {entry.flow}
                             </span>
                           </div>
                         </div>
                       )}
                       <div className="mt-3 space-y-1">
                         <p className="text-sm text-gray-400">Flow:</p>
+                        <div className="flex items-center gap-2">
+                          <div className="flex">
+                            {Array.from(
+                              { length: flowData?.droplets ?? 1 },
+                              (_, index) => (
+                                <Droplet
+                                  key={index}
+                                  className="h-4 w-4 text-pink-500"
+                                />
+                              ),
+                            )}
+                          </div>
 
-                        <p className="capitalize text-gray-700">{entry.flow}</p>
+                          <span className="capitalize text-gray-700">
+                            {entry.flow}
+                          </span>
+                        </div>{" "}
                       </div>
                     </div>
                   </div>

--- a/src/screens/HistoryScreen.tsx
+++ b/src/screens/HistoryScreen.tsx
@@ -46,25 +46,28 @@ function HistoryScreen({ entries, onDelete }: HistoryScreenProps) {
                         End: {formatPrettyDate(entry.endDate)}
                       </p>
                     )}
-                    {entry.mood && (
-                      <div className="mt-3 space-y-1">
-                        <p className="text-sm text-gray-400">Mood:</p>
 
-                        <div className="flex items-center gap-2">
-                          {MoodIcon && (
-                            <MoodIcon className="h-5 w-5 text-pink-500" />
-                          )}
+                    <div className="mt-3 flex gap-8">
+                      {entry.mood && (
+                        <div className="mt-3 space-y-1">
+                          <p className="text-sm text-gray-400">Mood:</p>
 
-                          <span className="capitalize text-gray-700">
-                            {entry.mood}
-                          </span>
+                          <div className="flex items-center gap-2">
+                            {MoodIcon && (
+                              <MoodIcon className="h-5 w-5 text-pink-500" />
+                            )}
+
+                            <span className="capitalize text-gray-700">
+                              {entry.mood}
+                            </span>
+                          </div>
                         </div>
-                      </div>
-                    )}
-                    <div className="mt-3 space-y-1">
-                      <p className="text-sm text-gray-400">Flow:</p>
+                      )}
+                      <div className="mt-3 space-y-1">
+                        <p className="text-sm text-gray-400">Flow:</p>
 
-                      <p className="capitalize text-gray-700">{entry.flow}</p>
+                        <p className="capitalize text-gray-700">{entry.flow}</p>
+                      </div>
                     </div>
                   </div>
 


### PR DESCRIPTION
Summary: Add flow intensity indicators to history cards
#### What changed

- Added visual representation of flow intensity using droplet icons
- Flow is now displayed as:
      - 💧 Light
      - 💧💧 Medium
      - 💧💧💧 Heavy

- Reused existing flows source of truth for consistency across the app
- Improved layout consistency in history cards alongside mood data

#### Why this change was made

- Previously, flow was displayed as plain text only. This made it harder to quickly scan and compare cycle intensity over time. Adding visual indicators improves readability and strengthens the UX consistency with the tracker screen.

#### UX impact

- Faster recognition of flow intensity at a glance
- More visually balanced history cards
- Consistent icon-based language across mood and flow tracking

#### Notes

- Flow uses Lucide Droplet icons repeated based on intensity value
- No changes to data model or storage logic