### PR TITLE
feat: show most recent periods first in history

### DIFF
--- a/src/screens/HistoryScreen.tsx
+++ b/src/screens/HistoryScreen.tsx
@@ -14,7 +14,8 @@ interface HistoryScreenProps {
 
 function HistoryScreen({ entries, onDelete }: HistoryScreenProps) {
   const [showAllHistory, setShowAllHistory] = useState(false);
-  const displayedEntries = showAllHistory ? entries : entries.slice(0, 3);
+  const sortedEntries = [...entries].reverse();
+  const displayedEntries = showAllHistory ? sortedEntries : sortedEntries.slice(0, 3);
 
   return (
     <div className="min-h-screen bg-linear-to-br from-purple-50 to-pink-50 px-4 py-6">
@@ -115,7 +116,7 @@ function HistoryScreen({ entries, onDelete }: HistoryScreenProps) {
           >
             {showAllHistory
               ? "Show less ↑"
-              : `View ${entries.length - 3} previous periods ↓`}
+              : `Show older entries ↓`}
           </button>
         )}
 


### PR DESCRIPTION
### Summary : Show most recent periods first in history

#### What changed

* Reversed the history order so the newest periods are displayed first.
* Updated the collapsed history view to show the three most recent entries by default.
* Small text change for more natural sounding language. 

#### Why

Displaying the oldest entries first made the "View previous periods" action confusing. Showing the latest periods first better matches user expectations and makes older entries easier to access when expanding the history list.

#### UX impact

* Recent cycle information is immediately visible.
* Expanded history now reveals older periods in chronological order.
* Improves clarity and navigation within the history screen.
